### PR TITLE
Simplifications for close app. settings

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -132,9 +132,7 @@ class MainWindow:
         self.popover_menu = UI("popover_menu")
 
         # Settings switch buttons
-        self.sw_closeapp_pardus = UI("sw_closeapp_pardus")
-        self.sw_closeapp_hdd = UI("sw_closeapp_hdd")
-        self.sw_closeapp_usb = UI("sw_closeapp_usb")
+        self.sw_closeapp_directories = UI("sw_closeapp_directories")
         self.sw_autorefresh = UI("sw_autorefresh")
 
         self.img_settings = UI("img_settings")
@@ -222,9 +220,7 @@ class MainWindow:
         self.UserSettings.createDefaultConfig()
         self.UserSettings.readConfig()
 
-        print("{} {}".format("config_closeapp_pardus", self.UserSettings.config_closeapp_pardus))
-        print("{} {}".format("config_closeapp_hdd", self.UserSettings.config_closeapp_hdd))
-        print("{} {}".format("config_closeapp_usb", self.UserSettings.config_closeapp_usb))
+        print("{} {}".format("config_closeapp_directories", self.UserSettings.config_closeapp_directories))
         print("{} {}".format("config_autorefresh", self.UserSettings.config_autorefresh))
         print("{} {}".format("config_autorefresh_time", self.UserSettings.config_autorefresh_time))
 
@@ -954,12 +950,12 @@ class MainWindow:
     # SIGNALS:
     def on_lb_home_row_activated(self, listbox, row):
         subprocess.run(["xdg-open", GLib.get_home_dir()])
-        if self.UserSettings.config_closeapp_pardus:
+        if self.UserSettings.config_closeapp_directories:
             self.onDestroy(listbox)
 
     def on_lb_root_row_activated(self, listbox, row):
         subprocess.run(["xdg-open", "/"])
-        if self.UserSettings.config_closeapp_pardus:
+        if self.UserSettings.config_closeapp_directories:
             self.onDestroy(listbox)
 
     def on_btn_mount_clicked(self, button):
@@ -1132,16 +1128,7 @@ class MainWindow:
                     self.showVolumeSizes(row)
 
             if not isinstance(row._volume, str):
-                if row._volume.get_drive():
-                    if row._volume.get_drive().is_removable():
-                        if self.UserSettings.config_closeapp_usb:
-                            self.onDestroy(row)
-                    else:
-                        if self.UserSettings.config_closeapp_hdd:
-                            self.onDestroy(row)
-                else:
-                    if self.UserSettings.config_closeapp_usb:
-                        self.onDestroy(row)
+                self.onDestroy(row)
 
     def on_btn_volume_info_clicked(self, button):
         # clear all disk info labels
@@ -1219,46 +1206,12 @@ class MainWindow:
         print("Manually refreshing disks")
         self.addDisksToGUI()
 
-    def on_sw_closeapp_pardus_state_set(self, switch, state):
-        user_config_closeapp_pardus = self.UserSettings.config_closeapp_pardus
-        if state != user_config_closeapp_pardus:
-            print("Updating close app pardus state")
+    def on_sw_closeapp_directories_state_set(self, switch, state):
+        user_config_closeapp_directories = self.UserSettings.config_closeapp_directories
+        if state != user_config_closeapp_directories:
+            print("Updating close app directories state")
             try:
                 self.UserSettings.writeConfig(state,
-                                              self.UserSettings.config_closeapp_hdd,
-                                              self.UserSettings.config_closeapp_usb,
-                                              self.UserSettings.config_autorefresh,
-                                              self.UserSettings.config_autorefresh_time
-                                              )
-                self.user_settings()
-            except Exception as e:
-                print("{}".format(e))
-        self.control_defaults()
-
-    def on_sw_closeapp_hdd_state_set(self, switch, state):
-        user_config_closeapp_hdd = self.UserSettings.config_closeapp_hdd
-        if state != user_config_closeapp_hdd:
-            print("Updating close app hdd state")
-            try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
-                                              state,
-                                              self.UserSettings.config_closeapp_usb,
-                                              self.UserSettings.config_autorefresh,
-                                              self.UserSettings.config_autorefresh_time
-                                              )
-                self.user_settings()
-            except Exception as e:
-                print("{}".format(e))
-        self.control_defaults()
-
-    def on_sw_closeapp_usb_state_set(self, switch, state):
-        user_config_closeapp_usb = self.UserSettings.config_closeapp_usb
-        if state != user_config_closeapp_usb:
-            print("Updating close app usb state")
-            try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
-                                              self.UserSettings.config_closeapp_hdd,
-                                              state,
                                               self.UserSettings.config_autorefresh,
                                               self.UserSettings.config_autorefresh_time
                                               )
@@ -1272,9 +1225,7 @@ class MainWindow:
         if state != user_config_autorefresh:
             print("Updating autorefresh state")
             try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
-                                              self.UserSettings.config_closeapp_hdd,
-                                              self.UserSettings.config_closeapp_usb,
+                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_directories,
                                               state,
                                               self.UserSettings.config_autorefresh_time
                                               )
@@ -1588,9 +1539,7 @@ class MainWindow:
             self.stack_main.set_visible_child_name("home")
             self.img_settings.set_from_icon_name("preferences-system-symbolic", Gtk.IconSize.BUTTON)
         elif self.stack_main.get_visible_child_name() == "home":
-            self.sw_closeapp_pardus.set_state(self.UserSettings.config_closeapp_pardus)
-            self.sw_closeapp_hdd.set_state(self.UserSettings.config_closeapp_hdd)
-            self.sw_closeapp_usb.set_state(self.UserSettings.config_closeapp_usb)
+            self.sw_closeapp_directories.set_state(self.UserSettings.config_closeapp_directories)
             self.sw_autorefresh.set_state(self.UserSettings.config_autorefresh)
             self.stack_main.set_visible_child_name("settings")
             self.img_settings.set_from_icon_name("user-home-symbolic", Gtk.IconSize.BUTTON)
@@ -1599,15 +1548,11 @@ class MainWindow:
     def on_btn_defaults_clicked(self, button):
         self.UserSettings.createDefaultConfig(force=True)
         self.user_settings()
-        self.sw_closeapp_pardus.set_state(self.UserSettings.config_closeapp_pardus)
-        self.sw_closeapp_hdd.set_state(self.UserSettings.config_closeapp_hdd)
-        self.sw_closeapp_usb.set_state(self.UserSettings.config_closeapp_usb)
+        self.sw_closeapp_directories.set_state(self.UserSettings.config_closeapp_directories)
         self.sw_autorefresh.set_state(self.UserSettings.config_autorefresh)
 
     def control_defaults(self):
-        if self.UserSettings.config_closeapp_pardus != self.UserSettings.default_closeapp_pardus or \
-                self.UserSettings.config_closeapp_hdd != self.UserSettings.default_closeapp_hdd or \
-                self.UserSettings.config_closeapp_usb != self.UserSettings.default_closeapp_usb or \
+        if self.UserSettings.config_closeapp_directories != self.UserSettings.default_closeapp_directories or \
                 self.UserSettings.config_autorefresh != self.UserSettings.default_autorefresh or \
                 self.UserSettings.config_autorefresh_time != self.UserSettings.default_autorefresh_time:
             self.btn_defaults.set_sensitive(True)

--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -19,24 +19,18 @@ class UserSettings(object):
         self.user_saved_servers_file = Path.joinpath(self.user_config_dir, Path("servers-saved"))
 
         self.config = configparser.ConfigParser(strict=False)
-        self.config_closeapp_pardus = None
-        self.config_closeapp_hdd = None
-        self.config_closeapp_usb = None
+        self.config_closeapp_directories = None
         self.config_autorefresh = None
         self.config_autorefresh_time = None
 
-        self.default_closeapp_pardus = False
-        self.default_closeapp_hdd = False
-        self.default_closeapp_usb = False
+        self.default_closeapp_directories = False
         self.default_autorefresh = False
         self.default_autorefresh_time = 1.5
 
 
     def createDefaultConfig(self, force=False):
         self.config['MAIN'] = {
-            'CloseAppPardus': 'no',
-            'CloseAppHDD': 'no',
-            'CloseAppUSB': 'no',
+            'CloseAppDirectories': 'no',
             'AutoRefresh': 'no',
             'AutoRefreshTime': 1.5
         }
@@ -49,9 +43,7 @@ class UserSettings(object):
     def readConfig(self):
         try:
             self.config.read(self.user_config_file)
-            self.config_closeapp_pardus = self.config.getboolean('MAIN', 'CloseAppPardus')
-            self.config_closeapp_hdd = self.config.getboolean('MAIN', 'CloseAppHDD')
-            self.config_closeapp_usb = self.config.getboolean('MAIN', 'CloseAppUSB')
+            self.config_closeapp_directories = self.config.getboolean('MAIN', 'CloseAppDirectories')
             self.config_autorefresh = self.config.getboolean('MAIN', 'AutoRefresh')
             self.config_autorefresh_time = self.config.getfloat('MAIN', 'AutoRefreshTime')
 
@@ -59,9 +51,7 @@ class UserSettings(object):
             print("{}".format(e))
             print("user config read error ! Trying create defaults")
             # if not read; try to create defaults
-            self.config_closeapp_pardus = self.default_closeapp_pardus
-            self.config_closeapp_hdd = self.default_closeapp_hdd
-            self.config_closeapp_usb = self.default_closeapp_usb
+            self.config_closeapp_directories = self.default_closeapp_directories
             self.config_autorefresh = self.default_autorefresh
             self.config_autorefresh_time = self.default_autorefresh_time
             try:
@@ -69,11 +59,9 @@ class UserSettings(object):
             except Exception as e:
                 print("self.createDefaultConfig(force=True) : {}".format(e))
 
-    def writeConfig(self, closeapppardus, closeapphdd, closeappusb, autorefresh, autorefreshtime):
+    def writeConfig(self, closeappdirectories, autorefresh, autorefreshtime):
         self.config['MAIN'] = {
-            'CloseAppPardus': closeapppardus,
-            'CloseAppHDD': closeapphdd,
-            'CloseAppUSB': closeappusb,
+            'CloseAppDirectories': closeappdirectories,
             'AutoRefresh': autorefresh,
             'AutoRefreshTime': autorefreshtime
         }

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -2238,7 +2238,7 @@ Fatih Altun</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Close app when Main directories are opened</property>
+                        <property name="label" translatable="yes">Close app when directories are opened</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -2247,12 +2247,12 @@ Fatih Altun</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkSwitch" id="sw_closeapp_pardus">
+                      <object class="GtkSwitch" id="sw_closeapp_directories">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <signal name="state-set" handler="on_sw_closeapp_pardus_state_set" swapped="no"/>
+                        <signal name="state-set" handler="on_sw_closeapp_directories_state_set" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -2265,86 +2265,6 @@ Fatih Altun</property>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="spacing">13</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Close app when Hard Drives are opened</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch" id="sw_closeapp_hdd">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="halign">end</property>
-                        <property name="valign">center</property>
-                        <signal name="state-set" handler="on_sw_closeapp_hdd_state_set" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="spacing">13</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Close app when Removable Drives are opened</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch" id="sw_closeapp_usb">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="halign">end</property>
-                        <property name="valign">center</property>
-                        <signal name="state-set" handler="on_sw_closeapp_usb_state_set" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -2384,7 +2304,7 @@ Fatih Altun</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Some changes for a simpler GUI:
Removed close application settings for HDD and USB devices. The setting for folders is renamed as "directories". The single option includes folders, HDDs and USBs.

You can check the modified code. There may be mistakes. It is not tested for removable devices.

Currently, there are two settings options. I will add an option for saving window size.