### PR TITLE
Added remember window size feature

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -222,6 +222,7 @@ class MainWindow:
         self.UserSettings.createDefaultConfig()
         self.UserSettings.readConfig()
 
+        print("{} {}".format("config_remember_window_size", self.UserSettings.config_remember_window_size))
         print("{} {}".format("config_closeapp_pardus", self.UserSettings.config_closeapp_pardus))
         print("{} {}".format("config_closeapp_hdd", self.UserSettings.config_closeapp_hdd))
         print("{} {}".format("config_closeapp_usb", self.UserSettings.config_closeapp_usb))
@@ -947,7 +948,44 @@ class MainWindow:
 
     # Window methods:
     def onDestroy(self, action):
+
         self.window.get_application().quit()
+
+    def on_window_delete_event(self, window, data=None):
+
+        # Get and save window state (if full screen or not), window size (width, height)
+        remember_window_size_value = True
+        main_window_state = window.is_maximized()
+        main_window_width, main_window_height = window.get_size()
+        remember_window_size_value_current = [remember_window_size_value, main_window_state, main_window_width, main_window_height]
+
+        user_config_remember_window_size = self.UserSettings.config_remember_window_size
+        if remember_window_size_value_current != user_config_remember_window_size:
+            print("Saving remember window size value")
+            try:
+                self.UserSettings.writeConfig(remember_window_size_value_current,
+                                              self.UserSettings.config_closeapp_pardus,
+                                              self.UserSettings.config_closeapp_hdd,
+                                              self.UserSettings.config_closeapp_usb,
+                                              self.UserSettings.config_autorefresh,
+                                              self.UserSettings.config_autorefresh_time
+                                              )
+                self.user_settings()
+            except Exception as e:
+                print("{}".format(e))
+        self.control_defaults()
+
+        self.window.get_application().quit()
+
+    def on_window_show(self, window):
+
+        # Resize/set state (full screen or not) of the application window
+        remember_window_size_value = self.UserSettings.config_remember_window_size
+        if remember_window_size_value[0] == True:
+            if remember_window_size_value[1] == True:
+                window.maximize()
+            else:
+                window.resize(remember_window_size_value[2], remember_window_size_value[3])
 
 
 
@@ -1224,7 +1262,8 @@ class MainWindow:
         if state != user_config_closeapp_pardus:
             print("Updating close app pardus state")
             try:
-                self.UserSettings.writeConfig(state,
+                self.UserSettings.writeConfig(self.UserSettings.config_remember_window_size,
+                                              state,
                                               self.UserSettings.config_closeapp_hdd,
                                               self.UserSettings.config_closeapp_usb,
                                               self.UserSettings.config_autorefresh,
@@ -1240,7 +1279,8 @@ class MainWindow:
         if state != user_config_closeapp_hdd:
             print("Updating close app hdd state")
             try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
+                self.UserSettings.writeConfig(self.UserSettings.config_remember_window_size,
+                                              self.UserSettings.config_closeapp_pardus,
                                               state,
                                               self.UserSettings.config_closeapp_usb,
                                               self.UserSettings.config_autorefresh,
@@ -1256,7 +1296,8 @@ class MainWindow:
         if state != user_config_closeapp_usb:
             print("Updating close app usb state")
             try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
+                self.UserSettings.writeConfig(self.UserSettings.config_remember_window_size,
+                                              self.UserSettings.config_closeapp_pardus,
                                               self.UserSettings.config_closeapp_hdd,
                                               state,
                                               self.UserSettings.config_autorefresh,
@@ -1272,7 +1313,8 @@ class MainWindow:
         if state != user_config_autorefresh:
             print("Updating autorefresh state")
             try:
-                self.UserSettings.writeConfig(self.UserSettings.config_closeapp_pardus,
+                self.UserSettings.writeConfig(self.UserSettings.config_remember_window_size,
+                                              self.UserSettings.config_closeapp_pardus,
                                               self.UserSettings.config_closeapp_hdd,
                                               self.UserSettings.config_closeapp_usb,
                                               state,

--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -19,12 +19,14 @@ class UserSettings(object):
         self.user_saved_servers_file = Path.joinpath(self.user_config_dir, Path("servers-saved"))
 
         self.config = configparser.ConfigParser(strict=False)
+        self.config_remember_window_size = None
         self.config_closeapp_pardus = None
         self.config_closeapp_hdd = None
         self.config_closeapp_usb = None
         self.config_autorefresh = None
         self.config_autorefresh_time = None
 
+        self.default_remember_window_size = [True, False, 700, 550]
         self.default_closeapp_pardus = False
         self.default_closeapp_hdd = False
         self.default_closeapp_usb = False
@@ -34,6 +36,7 @@ class UserSettings(object):
 
     def createDefaultConfig(self, force=False):
         self.config['MAIN'] = {
+            'RememberWindowSize': 'yes, no, 700, 550',
             'CloseAppPardus': 'no',
             'CloseAppHDD': 'no',
             'CloseAppUSB': 'no',
@@ -49,6 +52,21 @@ class UserSettings(object):
     def readConfig(self):
         try:
             self.config.read(self.user_config_file)
+
+            # "config_remember_window_size" setting is a list.
+            # It is processed by using the following code.
+            remember_window_size = self.config.get('MAIN', 'RememberWindowSize').strip("[]").split(", ")
+            remember_window_size_converted = []
+            for i, value in enumerate(remember_window_size):
+                if i == 0 or i == 1:
+                    if value == "True":
+                        remember_window_size_converted.append(True)
+                    else:
+                        remember_window_size_converted.append(False)
+                if i == 2 or i == 3:
+                    remember_window_size_converted.append(int(value))
+
+            self.config_remember_window_size = remember_window_size_converted
             self.config_closeapp_pardus = self.config.getboolean('MAIN', 'CloseAppPardus')
             self.config_closeapp_hdd = self.config.getboolean('MAIN', 'CloseAppHDD')
             self.config_closeapp_usb = self.config.getboolean('MAIN', 'CloseAppUSB')
@@ -59,6 +77,7 @@ class UserSettings(object):
             print("{}".format(e))
             print("user config read error ! Trying create defaults")
             # if not read; try to create defaults
+            self.config_remember_window_size = self.default_remember_window_size
             self.config_closeapp_pardus = self.default_closeapp_pardus
             self.config_closeapp_hdd = self.default_closeapp_hdd
             self.config_closeapp_usb = self.default_closeapp_usb
@@ -69,8 +88,9 @@ class UserSettings(object):
             except Exception as e:
                 print("self.createDefaultConfig(force=True) : {}".format(e))
 
-    def writeConfig(self, closeapppardus, closeapphdd, closeappusb, autorefresh, autorefreshtime):
+    def writeConfig(self, rememberwindowsize, closeapppardus, closeapphdd, closeappusb, autorefresh, autorefreshtime):
         self.config['MAIN'] = {
+            'RememberWindowSize': rememberwindowsize,
             'CloseAppPardus': closeapppardus,
             'CloseAppHDD': closeapphdd,
             'CloseAppUSB': closeappusb,

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -1622,6 +1622,8 @@ Fatih Altun</property>
     <property name="default-width">700</property>
     <property name="default-height">550</property>
     <property name="icon-name">pardus-mycomputer</property>
+    <signal name="delete-event" handler="on_window_delete_event" swapped="no"/>
+    <signal name="show" handler="on_window_show" swapped="no"/>
     <child>
       <object class="GtkStack" id="stack_main">
         <property name="visible">True</property>


### PR DESCRIPTION
Currently, window size is remembered by default. A separate pull request can be sent if you want an option for it. I think there is no need for an option for enabling/disabling "remember window size" feature.

You can check "readConfig" function in the UserSettings module. The new setting is not read by using a single line code. Because it is a list.