### PR TITLE
Fixed process name of the application

### DIFF
--- a/pardus-mycomputer
+++ b/pardus-mycomputer
@@ -1,2 +1,6 @@
-#!/bin/sh
-/usr/bin/python3 /usr/share/pardus/pardus-mycomputer/src/pardus-mycomputer
+#!/usr/bin/python3
+
+import sys
+sys.path.insert(0, '/usr/share/pardus/pardus-mycomputer/src/')
+import Main
+

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ data_files = [
     ("/usr/share/applications/", ["tr.org.pardus.mycomputer.desktop"]),
     ("/usr/share/pardus/pardus-mycomputer/", ["pardus-mycomputer.svg"]),
     ("/usr/share/pardus/pardus-mycomputer/src", [
-        "src/pardus-mycomputer",
+        "src/Main.py",
         "src/MainWindow.py",
         "src/DiskManager.py",
         "src/Unmount.py",

--- a/src/Main.py
+++ b/src/Main.py
@@ -15,6 +15,5 @@ class Application(Gtk.Application):
         self.window = MainWindow(self)
 
 
-if __name__ == "__main__":
-    app = Application()
-    app.run(sys.argv)
+app = Application()
+app.run(sys.argv)


### PR DESCRIPTION
Note: **Feel free to cancel the pull request.**

There were two process names:
pardus-mycomputer and python3
The first one was for the shell process (in the /bin folder)
The second one was for the application. CPU and memory usage of the application were shown by using python3 process.
![pmc_process_name_before](https://user-images.githubusercontent.com/90193017/212742525-fc672ce7-f263-48b6-a505-a5b06b145c25.png)

After the change there is one process for the application. CPU and memory usage are shown by using this process.
![pmc_process_name](https://user-images.githubusercontent.com/90193017/212742545-4f505d89-7a11-4c7b-a82b-4b8a952b5025.png)
