### PR TITLE
feat: better support for XDG Base Directory

### DIFF
--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -30,7 +30,8 @@ class UserSettings(object):
     def __init__(self):
 
         self.user_home = Path.home()
-        self.user_config_dir = Path.joinpath(self.user_home, Path(".config/pardus-mycomputer"))
+        self.xdg_config_home = Path(os.environ.get("XDG_CONFIG_HOME")) if os.environ.get("XDG_CONFIG_HOME") else Path.joinpath(self.user_home, Path(".config"))
+        self.user_config_dir = Path.joinpath(self.xdg_config_home, "pardus-mycomputer")
         self.user_config_file = Path.joinpath(self.user_config_dir, Path("settings.ini"))
         self.user_recent_servers_file = Path.joinpath(self.user_config_dir, Path("servers-recent"))
         self.user_saved_servers_file = Path.joinpath(self.user_config_dir, Path("servers-saved"))


### PR DESCRIPTION
This PR removes the hardcoded path for the user configuration directory ($HOME/.config/) and instead uses the environment variable XDG_CONFIG_HOME. This allows users to have more control over where the configuration files are stored.