### PR TITLE
Update config directory

### DIFF
--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -32,6 +32,8 @@ class UserSettings(object):
         self.user_home = Path.home()
         self.xdg_config_home = Path(os.environ.get("XDG_CONFIG_HOME", str(self.user_home) + "/.config")) 
         self.user_config_dir = Path.joinpath(self.xdg_config_home, Path("pardus-mycomputer"))
+        if not os.path.exists(self.user_config_dir):
+            self.user_config_dir = Path.joinpath(self.xdg_config_home, Path("pardus/pardus-mycomputer"))
         self.user_config_file = Path.joinpath(self.user_config_dir, Path("settings.ini"))
         self.user_recent_servers_file = Path.joinpath(self.user_config_dir, Path("servers-recent"))
         self.user_saved_servers_file = Path.joinpath(self.user_config_dir, Path("servers-saved"))


### PR DESCRIPTION
This PR updates the pardus mycomputer config directory to follow the most of Pardus applications structure (`~/.config/pardus/app-name/`). (pardus mycomputer is using `~/.config/pardus-mycomputer`.)

This change ensures consistency with other Pardus applications. Backward compatibility is ensured for existing configurations.

This pr based on commits from (#20 )