### PR TITLE
Otomatik sftp sunucularını tarama ve gösterme

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Depends: ${misc:Depends},
          gir1.2-glib-2.0,
          gir1.2-gtk-3.0,
          gir1.2-notify-0.7,
-         gir1.2-pango-1.0
+         gir1.2-pango-1.0,
+         python3-paramiko
 Recommends: gvfs-fuse,
             libglib2.0-bin
 Description: My Computer, shows general information about your computer.

--- a/po/files
+++ b/po/files
@@ -1,3 +1,4 @@
 ui/MainWindow.glade
 src/MainWindow.py
 src/UserSettings.py
+src/Scansftp.py

--- a/po/tr.po
+++ b/po/tr.po
@@ -521,10 +521,6 @@ msgstr "Ağa bağlı sunucuları bulun:"
 msgid "Scanning the SFTP servers on the network.."
 msgstr "Ağdaki SFTP sunucuları taranıyor..."
 
-#: ui/MainWindow.glade:2320
-msgid "Scan"
-msgstr "Tara"
-
 #: ui/MainWindow.glade:2344
 msgid "Scan"
 msgstr "Tara"

--- a/po/tr.po
+++ b/po/tr.po
@@ -518,7 +518,7 @@ msgid "Find the servers connected to the network:"
 msgstr "Ağa bağlı sunucuları bulun:"
 
 #: ui/MainWindow.glade:2248
-msgid "Scanning the SFTP servers on the network.."
+msgid "Scanning the SFTP servers on the network..."
 msgstr "Ağdaki SFTP sunucuları taranıyor..."
 
 #: ui/MainWindow.glade:2344

--- a/po/tr.po
+++ b/po/tr.po
@@ -512,3 +512,19 @@ msgstr "# not: görünmesini sağlamak için kare işareti kaldırın"
 
 #~ msgid "Website"
 #~ msgstr "Website"
+
+#: ui/MainWindow.glade:2248
+msgid "Find the servers connected to the network:"
+msgstr "Ağa bağlı sunucuları bulun:"
+
+#: ui/MainWindow.glade:2248
+msgid "Scanning the SFTP servers on the network.."
+msgstr "Ağdaki SFTP sunucuları taranıyor..."
+
+#: ui/MainWindow.glade:2320
+msgid "Scan"
+msgstr "Tara"
+
+#: ui/MainWindow.glade:2344
+msgid "Scan"
+msgstr "Tara"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ data_files = [
                      "src/DiskManager.py",
                      "src/Unmount.py",
                      "src/UserSettings.py",
+                     "src/Scansftp.py",
                      "src/__version__"
                  ]),
                  ("/usr/share/pardus/pardus-mycomputer/ui",

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -14,6 +14,7 @@ import DiskManager
 
 from UserSettings import UserSettings
 
+import threading
 import Scansftp  # sftp scan function library
 
 import locale
@@ -217,6 +218,8 @@ class MainWindow:
         self.btn_mount_connect = UI("btn_mount_connect")
         self.btn_sftp_scan = UI("btn_sftp_scan")  # sftp scan button
         self.sftp_listbox = UI("sftp_listbox")  # sftp list box
+        self.sftp_stack = UI("sftp_stack")  # sftp stack panel
+        self.scrolledwindow = UI("scrolledwindow")
         self.mount_password_options = UI("mount_password_options")
         self.mount_anonym_options = UI("mount_anonym_options")
         self.popover_connect = UI("popover_connect")
@@ -2100,15 +2103,40 @@ class MainWindow:
         box.name = "{} {}".format(uri, name).strip()
         self.listbox_recent_servers.add(box)
 
+    def remove_from_recent_clicked(self, button):
+        for row in self.listbox_recent_servers:
+            if row.get_children()[0].name == button.name:
+                self.listbox_recent_servers.remove(row)
+
+        self.UserSettings.removeRecentServer(button.name)
+
+
 
     # sftp scan function
     def on_sftp_scan(self, button):
-        netaddress = Scansftp.get_local_network()
-        scanned_devices = Scansftp.scan_devices(netaddress)
+        self.sftp_stack.set_visible_child_name('page1')
+        # Arka plan thread başlat
+        threading.Thread(target=self.scan_process, daemon=True).start()
+
+    def scan_process(self):
+        try:
+            netaddress = Scansftp.get_local_network()
+            scanned_devices = Scansftp.scan_devices(netaddress)
+        except Exception as e:
+            #GLib.idle_add(self._on_scan_done, None, e)
+            return
+        GLib.idle_add(self.sftp_listboxadd, scanned_devices)
+
+    def sftp_listboxadd(self, scanned_devices):
+        # Listeyi güncelle
+        self.sftp_listbox.foreach(lambda w: self.sftp_listbox.remove(w))
+        self.sftp_listbox.set_hexpand(True)
+        self.sftp_listbox.set_vexpand(True)
         for d in scanned_devices:
-            if Scansftp.is_sftp_server(d['ip']):
-                linebutton = self.make_sftp_listbox_button(d['ip'], on_clicked=self.server_entry_settext)
-                self.sftp_listbox.add(linebutton)
+            row = self.make_sftp_listbox_button(d, on_clicked=self.server_entry_settext)
+            self.sftp_listbox.add(row)
+
+        self.sftp_stack.set_visible_child_name('page0')
         self.sftp_listbox.show_all()
 
     def make_sftp_listbox_button(self, label_text, on_clicked=None):
@@ -2128,18 +2156,11 @@ class MainWindow:
         return row
 
     def server_entry_settext(self, button):
-        ip = button.get_label()
+        ip = button.get_label().strip()
         self.entry_addr.set_text("sftp://"+ip)
 
 
-    def remove_from_recent_clicked(self, button):
-        for row in self.listbox_recent_servers:
-            if row.get_children()[0].name == button.name:
-                self.listbox_recent_servers.remove(row)
-
-        self.UserSettings.removeRecentServer(button.name)
-
-    def on_btn_mount_connect_clicked(self, button, from_saved=False, saved_uri="", from_places=False, scan_req=False):
+    def on_btn_mount_connect_clicked(self, button, from_saved=False, saved_uri="", from_places=False):
         def get_uri_name(source_object):
             try:
                 uri = source_object.get_uri()
@@ -2270,12 +2291,7 @@ class MainWindow:
         if not from_saved:
 
             self.popover_connect.popdown()
-            if scan_req == False:
-                print("scan_req False")
-                addr = self.entry_addr.get_text()
-            else:
-                print("scan_req True")
-                addr = scan_req
+            addr = self.entry_addr.get_text()
 
             file = Gio.File.new_for_commandline_arg(addr)
             mount_operation = Gio.MountOperation()

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -14,6 +14,8 @@ import DiskManager
 
 from UserSettings import UserSettings
 
+import Scansftp  # sftp scan function library
+
 import locale
 from locale import gettext as _
 
@@ -213,6 +215,8 @@ class MainWindow:
         self.box_user_domain_pass = UI("box_user_domain_pass")
         self.box_anonym = UI("box_anonym")
         self.btn_mount_connect = UI("btn_mount_connect")
+        self.btn_sftp_scan = UI("btn_sftp_scan")  # sftp scan button
+        self.sftp_listbox = UI("sftp_listbox")  # sftp list box
         self.mount_password_options = UI("mount_password_options")
         self.mount_anonym_options = UI("mount_anonym_options")
         self.popover_connect = UI("popover_connect")
@@ -2096,6 +2100,38 @@ class MainWindow:
         box.name = "{} {}".format(uri, name).strip()
         self.listbox_recent_servers.add(box)
 
+
+    # sftp scan function
+    def on_sftp_scan(self, button):
+        netaddress = Scansftp.get_local_network()
+        scanned_devices = Scansftp.scan_devices(netaddress)
+        for d in scanned_devices:
+            if Scansftp.is_sftp_server(d['ip']):
+                linebutton = self.make_sftp_listbox_button(d['ip'], on_clicked=self.server_entry_settext)
+                self.sftp_listbox.add(linebutton)
+        self.sftp_listbox.show_all()
+
+    def make_sftp_listbox_button(self, label_text, on_clicked=None):
+        # Row oluştur
+        row = Gtk.ListBoxRow()
+
+        # Button oluştur. Align/halign ile düzenleme yapabilirsiniz.
+        btn = Gtk.Button(label=label_text)
+        btn.set_hexpand(True)
+        btn.set_halign(Gtk.Align.FILL)
+
+        # Eğer callback verildiyse bağla; handler'a (button, user_data) gönderecek şekilde sar
+        if on_clicked is not None:
+            btn.connect("clicked", on_clicked)
+        # Button'u row içine ekle
+        row.add(btn)
+        return row
+
+    def server_entry_settext(self, button):
+        ip = button.get_label()
+        self.entry_addr.set_text("sftp://"+ip)
+
+
     def remove_from_recent_clicked(self, button):
         for row in self.listbox_recent_servers:
             if row.get_children()[0].name == button.name:
@@ -2103,7 +2139,7 @@ class MainWindow:
 
         self.UserSettings.removeRecentServer(button.name)
 
-    def on_btn_mount_connect_clicked(self, button, from_saved=False, saved_uri="", from_places=False):
+    def on_btn_mount_connect_clicked(self, button, from_saved=False, saved_uri="", from_places=False, scan_req=False):
         def get_uri_name(source_object):
             try:
                 uri = source_object.get_uri()
@@ -2234,7 +2270,12 @@ class MainWindow:
         if not from_saved:
 
             self.popover_connect.popdown()
-            addr = self.entry_addr.get_text()
+            if scan_req == False:
+                print("scan_req False")
+                addr = self.entry_addr.get_text()
+            else:
+                print("scan_req True")
+                addr = scan_req
 
             file = Gio.File.new_for_commandline_arg(addr)
             mount_operation = Gio.MountOperation()

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -2115,6 +2115,7 @@ class MainWindow:
     # sftp scan function
     def on_sftp_scan(self, button):
         self.sftp_stack.set_visible_child_name('page1')
+        self.btn_sftp_scan.set_sensitive(False)
         # Start background thread
         threading.Thread(target=self.scan_process, daemon=True).start()
 
@@ -2137,6 +2138,7 @@ class MainWindow:
 
         self.sftp_stack.set_visible_child_name('page0')
         self.sftp_listbox.show_all()
+        self.btn_sftp_scan.set_sensitive(True)
 
     def make_sftp_listbox_button(self, label_text, on_clicked=None):
         # Create row

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -2115,7 +2115,7 @@ class MainWindow:
     # sftp scan function
     def on_sftp_scan(self, button):
         self.sftp_stack.set_visible_child_name('page1')
-        # Arka plan thread başlat
+        # Start background thread
         threading.Thread(target=self.scan_process, daemon=True).start()
 
     def scan_process(self):
@@ -2123,12 +2123,11 @@ class MainWindow:
             netaddress = Scansftp.get_local_network()
             scanned_devices = Scansftp.scan_devices(netaddress)
         except Exception as e:
-            #GLib.idle_add(self._on_scan_done, None, e)
             return
         GLib.idle_add(self.sftp_listboxadd, scanned_devices)
 
     def sftp_listboxadd(self, scanned_devices):
-        # Listeyi güncelle
+        # Update the list
         self.sftp_listbox.foreach(lambda w: self.sftp_listbox.remove(w))
         self.sftp_listbox.set_hexpand(True)
         self.sftp_listbox.set_vexpand(True)
@@ -2140,18 +2139,16 @@ class MainWindow:
         self.sftp_listbox.show_all()
 
     def make_sftp_listbox_button(self, label_text, on_clicked=None):
-        # Row oluştur
+        # Create row
         row = Gtk.ListBoxRow()
 
-        # Button oluştur. Align/halign ile düzenleme yapabilirsiniz.
+        # Create a button. You can edit it using align/halign
         btn = Gtk.Button(label=label_text)
         btn.set_hexpand(True)
         btn.set_halign(Gtk.Align.FILL)
 
-        # Eğer callback verildiyse bağla; handler'a (button, user_data) gönderecek şekilde sar
         if on_clicked is not None:
             btn.connect("clicked", on_clicked)
-        # Button'u row içine ekle
         row.add(btn)
         return row
 

--- a/src/Scansftp.py
+++ b/src/Scansftp.py
@@ -69,7 +69,7 @@ def check_ssh_sftp(host, port=22, timeout=3):
         return False
 
 # scan devices
-def scan(network, max_threads=30, delay=0.02):
+def scan_devices(network, max_threads=30, delay=0.02):
     net = ipaddress.ip_network(network, strict=False)
     results = []
 
@@ -91,6 +91,7 @@ def scan(network, max_threads=30, delay=0.02):
             if res:
                 results.append(res)
 
+    print(results)
     return results
 
 

--- a/src/Scansftp.py
+++ b/src/Scansftp.py
@@ -1,0 +1,42 @@
+from scapy.all import ARP, Ether, srp
+import netifaces
+import ipaddress
+
+# a function that retrieves the network address of the connected interface
+def get_local_network():
+    # Find the interface used by the default gateway
+    gateway_info = netifaces.gateways()
+    interface = gateway_info['default'][netifaces.AF_INET][1]
+
+    # Interface IP and netmask information
+    addr_info = netifaces.ifaddresses(interface)[netifaces.AF_INET][0]
+
+    ip_addr = addr_info['addr']
+    netmask = addr_info['netmask']
+
+    # Create a network address
+    network = ipaddress.IPv4Network(f"{ip_addr}/{netmask}", strict=False)
+
+    return str(network)
+
+
+
+def arp_scan(network):
+    ether = Ether(dst="ff:ff:ff:ff:ff:ff")  # Broadcast Ethernet frame
+    arp = ARP(pdst=network)  # ARP package
+
+    packet = ether / arp
+
+    result = srp(packet, timeout=2, verbose=0)[0]  # send package
+
+    devices = []
+
+    for sent, received in result:
+        devices.append({"ip": received.psrc})
+
+    return devices
+
+#network = get_local_network()
+#print(network)
+#print(arp_scan(network))
+

--- a/src/Scansftp.py
+++ b/src/Scansftp.py
@@ -1,8 +1,10 @@
-from scapy.all import ARP, Ether, srp
-import netifaces
-import ipaddress
-import paramiko
+import subprocess
 import socket
+import ipaddress
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
+import paramiko
+import netifaces
 
 # a function that retrieves the network address of the connected interface
 def get_local_network():
@@ -22,23 +24,23 @@ def get_local_network():
     return str(network)
 
 
-def scan_devices(network):
-    ether = Ether(dst="ff:ff:ff:ff:ff:ff")  # Broadcast Ethernet frame
-    arp = ARP(pdst=network)  # ARP package
+def get_ip_neigh():
+    ips = set()
+    try:
+        out = subprocess.check_output(["ip", "neigh"]).decode()
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) > 0:
+                ip = parts[0]
+                if ip.count(".") == 3:  # IPv4 basic filter
+                    ips.add(ip)
+    except Exception as e:
+        print("ip neigh error:", e)
 
-    packet = ether / arp
-
-    result = srp(packet, timeout=2, verbose=0)[0]  # send package
-
-    devices = []
-
-    for sent, received in result:
-        devices.append({"ip": received.psrc})
-
-    return devices
+    return ips
 
 
-def is_sftp_server(host, port=22, timeout=3):
+def check_ssh_sftp(host, port=22, timeout=3):
     # Checking if the SSH port is open
     try:
         sock = socket.create_connection((host, port), timeout=timeout)
@@ -66,11 +68,34 @@ def is_sftp_server(host, port=22, timeout=3):
     except Exception:
         return False
 
+# scan devices
+def scan(network, max_threads=30, delay=0.02):
+    net = ipaddress.ip_network(network, strict=False)
+    results = []
+
+    def worker(ip):
+        ip = str(ip)
+        if check_ssh_sftp(ip):  # this address is being checked to see if it is an SSH server
+            return ip
+        return None
+
+    with ThreadPoolExecutor(max_workers=max_threads) as executor:
+        futures = []
+
+        for ip in net.hosts():
+            futures.append(executor.submit(worker, ip))
+            time.sleep(delay)
+
+        for f in as_completed(futures):
+            res = f.result()
+            if res:
+                results.append(res)
+
+    return results
+
+
 #netaddress = get_local_network()
-#devices = scan_devices(netaddress)
-#for d in devices:
-#    if is_sftp_server(d['ip']):
-#        print(f"{d} -- SFTP VAR")
-#    else:
-#        print(f"{d} -- SFTP YOK")
+#hosts = scan(netaddress)
+#for h in hosts:
+#    print(h)
 

--- a/src/Scansftp.py
+++ b/src/Scansftp.py
@@ -1,6 +1,8 @@
 from scapy.all import ARP, Ether, srp
 import netifaces
 import ipaddress
+import paramiko
+import socket
 
 # a function that retrieves the network address of the connected interface
 def get_local_network():
@@ -20,8 +22,7 @@ def get_local_network():
     return str(network)
 
 
-
-def arp_scan(network):
+def scan_devices(network):
     ether = Ether(dst="ff:ff:ff:ff:ff:ff")  # Broadcast Ethernet frame
     arp = ARP(pdst=network)  # ARP package
 
@@ -36,7 +37,40 @@ def arp_scan(network):
 
     return devices
 
-#network = get_local_network()
-#print(network)
-#print(arp_scan(network))
+
+def is_sftp_server(host, port=22, timeout=3):
+    # Checking if the SSH port is open
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.close()
+    except (socket.timeout, ConnectionRefusedError, OSError):
+        return False
+
+    # Sending a fake credential results in an    AuthenticationException → This means SFTP exists
+    transport = paramiko.Transport((host, port))
+    transport.banner_timeout = timeout
+
+    try:
+        transport.connect(
+            username='__probe__',
+            password='__probe__'
+        )
+        return True
+
+    except paramiko.AuthenticationException:
+        return True   # an authentication error means the SFTP service is active
+
+    except paramiko.SSHException:
+        return False  # SSH handshake failed
+
+    except Exception:
+        return False
+
+#netaddress = get_local_network()
+#devices = scan_devices(netaddress)
+#for d in devices:
+#    if is_sftp_server(d['ip']):
+#        print(f"{d} -- SFTP VAR")
+#    else:
+#        print(f"{d} -- SFTP YOK")
 

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -2223,6 +2223,79 @@ Fatih Altun &lt;fatih.altun@pardus.org.tr&gt;</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="sftp_scanner_box">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Find the servers connected to the network:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolled_window">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkListBox" id="sftp_listbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_sftp_scan">
+                <property name="label" translatable="yes">Scan</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_sftp_scan" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
       </object>
     </child>
   </object>

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -2238,11 +2238,13 @@ Fatih Altun &lt;fatih.altun@pardus.org.tr&gt;</property>
           <object class="GtkBox" id="sftp_scanner_box">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-top">10</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-bottom">13</property>
                 <property name="label" translatable="yes">Find the servers connected to the network:</property>
               </object>
               <packing>
@@ -2252,21 +2254,83 @@ Fatih Altun &lt;fatih.altun@pardus.org.tr&gt;</property>
               </packing>
             </child>
             <child>
-              <object class="GtkScrolledWindow" id="scrolled_window">
+              <object class="GtkStack" id="sftp_stack">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="shadow-type">in</property>
+                <property name="can-focus">False</property>
                 <child>
-                  <object class="GtkViewport">
+                  <object class="GtkBox" id="page0">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkListBox" id="sftp_listbox">
+                      <object class="GtkScrolledWindow" id="scrolled_window">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="margin-bottom">3</property>
+                        <property name="shadow-type">in</property>
+                        <property name="propagate-natural-width">True</property>
+                        <property name="propagate-natural-height">True</property>
+                        <child>
+                          <object class="GtkViewport">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkListBox" id="sftp_listbox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="name">page0</property>
+                    <property name="title" translatable="yes">page0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="page1">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="homogeneous">True</property>
+                    <child>
+                      <object class="GtkSpinner">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Scanning the SFTP servers on the network...</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">page1</property>
+                    <property name="title" translatable="yes">page1</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
@@ -2281,6 +2345,7 @@ Fatih Altun &lt;fatih.altun@pardus.org.tr&gt;</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
+                <property name="margin-top">16</property>
                 <signal name="clicked" handler="on_sftp_scan" swapped="no"/>
               </object>
               <packing>


### PR DESCRIPTION
Eklenen özellik kullanıcının bağlanabileceği sftp sunucularını tespit eder. Yerel ağdaki aktif ip adreslerinin 22 portu taranır, ve sftp hizmeti sağladıkları doğrulandıktan sonra listeye eklenir. Bu özellik sayesinde kullanıcı bağlanmak istediği lakin adresini bilmediği sunucuyu bulabilir.

<img width="852" height="699" alt="Ekran görüntüsü_2026-06-07_06-27-27" src="https://github.com/user-attachments/assets/e1cd50d0-2729-4980-b02c-edf73c7238a4" />
<img width="852" height="699" alt="Ekran görüntüsü_2026-06-07_06-27-37" src="https://github.com/user-attachments/assets/6adec7d8-0e46-4b4a-87bc-0c40f3f1c75c" />
<img width="852" height="699" alt="Ekran görüntüsü_2026-06-07_06-28-06" src="https://github.com/user-attachments/assets/d67a66df-d3a0-4683-bbdd-7d6f20ce5f29" />
<img width="852" height="699" alt="Ekran görüntüsü_2026-06-07_06-28-13" src="https://github.com/user-attachments/assets/7b35d5a3-6fb1-40ca-81a3-5cd952eb4bf4" />
<img width="345" height="283" alt="Ekran görüntüsü_2026-06-07_06-28-22" src="https://github.com/user-attachments/assets/f07a0a32-a3be-4956-b592-c455f9b14dae" />
